### PR TITLE
Pass the response object to the provideCtx callback

### DIFF
--- a/reason-graphql-bs-express/examples/server.re
+++ b/reason-graphql-bs-express/examples/server.re
@@ -18,7 +18,9 @@ module HelloWorldSchema = {
           nonnull(string),
           ~args=Arg.[defaultArg("name", string, ~default="world")],
           ~resolve=(ctx, (), name) =>
-          Js.Promise.resolve(Belt.Result.Ok(name ++ " (" ++ ctx.userIP ++ ")"))
+          Js.Promise.resolve(
+            Belt.Result.Ok(name ++ " (" ++ ctx.userIP ++ ")"),
+          )
         ),
       ])
     );
@@ -35,7 +37,7 @@ App.use(app, Middleware.json(~limit=ByteLimit.mb(5.0), ()));
 App.useOnPath(app, ~path="/graphql") @@
 GraphqlExpress.middleware(
   HelloWorldSchema.schema,
-  ~provideCtx=req => {userIP: Request.ip(req)},
+  ~provideCtx=(req, _res) => {userIP: Request.ip(req)},
   ~graphiql=true,
 );
 

--- a/reason-graphql-bs-express/src/GraphqlExpress.re
+++ b/reason-graphql-bs-express/src/GraphqlExpress.re
@@ -42,8 +42,15 @@ let middleware = (~provideCtx, ~graphiql=false, schema) =>
     | "POST" =>
       switch (parseBodyIntoDocumentAndVariables(req)) {
       | Ok((document, variables)) =>
-        GraphqlPromise.Schema.execute(schema, ~document, ~variables?, ~ctx=provideCtx(req))
-        |> Js.Promise.(then_(const => resolve(Graphql.Json.fromConstValue(const))))
+        GraphqlPromise.Schema.execute(
+          schema,
+          ~document,
+          ~variables?,
+          ~ctx=provideCtx(req, res),
+        )
+        |> Js.Promise.(
+             then_(const => resolve(Graphql.Json.fromConstValue(const)))
+           )
         |> Js.Promise.(then_(json => resolve(Response.sendJson(json, res))))
       | Error(error) =>
         res


### PR DESCRIPTION
BREAKING CHANGE: this changes the signature of the provideCtx callback.

The original motivation was to allow mutation code to set cookies on the
response.

The other two options I see are:
1. Making the middleware not terminating, so that next is always called and able to interact with the response. This is clunky and fragile.
2. Add specific facilities/interfaces for the required interactions graphql code might have with the response. My specific need was to be able to set cookies. There might be more in the future. 

This approach is the most open, though not the cleanest since it provides direct access to the response.