### PR TITLE
change GraphqlPromise to GraphqlJsPromise

### DIFF
--- a/reason-graphql-bs-express/examples/server.re
+++ b/reason-graphql-bs-express/examples/server.re
@@ -1,7 +1,7 @@
 type ctx = {userIP: string};
 
 module HelloWorldSchema = {
-  open GraphqlPromise;
+  open GraphqlJsPromise;
 
   let rootQuery =
     Schema.(

--- a/reason-graphql-bs-express/src/GraphqlExpress.re
+++ b/reason-graphql-bs-express/src/GraphqlExpress.re
@@ -42,7 +42,7 @@ let middleware = (~provideCtx, ~graphiql=false, schema) =>
     | "POST" =>
       switch (parseBodyIntoDocumentAndVariables(req)) {
       | Ok((document, variables)) =>
-        GraphqlPromise.Schema.execute(
+        GraphqlJsPromise.Schema.execute(
           schema,
           ~document,
           ~variables?,


### PR DESCRIPTION
Right now, the package `reason-graphql-bs-express` does not compile because of the module `GraphqlPromise` taht needs to be renamed `GraphqlJsPromise`